### PR TITLE
Fix issue with watched sync messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 *
 -->
 
-## [Unreleased]
+## [v1.5.1]
 
 ### Changed
 
-* Move config into own package
+* Move config into own package.
+
+## Fixed
+
+* ([#87](https://github.com/danstis/Plex-Sync/issues/87)) Update to return message if watched item has already been scrobbled on remote server.
 
 ## [v0.5.0]
 

--- a/plex/server.go
+++ b/plex/server.go
@@ -158,6 +158,8 @@ func SyncWatchedTv(source, destination Host) error {
 					continue
 				}
 				log.Printf("* Scrobbled on %q", destination.Name)
+			} else if destEp.ViewCount >= 1 {
+				log.Println("- Already scrobbled, skipping...")
 			} else {
 				log.Println("- Episode not yet watched, skipping...")
 			}


### PR DESCRIPTION
Update to return message if watched item has already been scrobbled on remote server.
Closes #87 